### PR TITLE
Request screen: add Send/Receive modes, draft requests, cloud fetch and matching

### DIFF
--- a/app/src/main/java/com/shary/app/ui/screens/request/RequestScreen.kt
+++ b/app/src/main/java/com/shary/app/ui/screens/request/RequestScreen.kt
@@ -25,12 +25,15 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavHostController
 import com.shary.app.core.domain.models.FieldDomain
+import com.shary.app.core.domain.models.RequestDomain
 import com.shary.app.core.domain.models.reset
 import com.shary.app.core.domain.types.enums.Tag
 import com.shary.app.ui.screens.home.utils.Screen
 import com.shary.app.ui.screens.request.utils.AddRequestDialog
 import com.shary.app.ui.screens.request.utils.SendRequestDialog
 import com.shary.app.ui.screens.utils.SpecialComponents.CompactActionButton
+import com.shary.app.ui.screens.utils.FieldMatchingDialog
+import com.shary.app.ui.screens.utils.LoadingOverlay
 import com.shary.app.viewmodels.communication.CloudViewModel
 import com.shary.app.viewmodels.communication.EmailViewModel
 import com.shary.app.viewmodels.field.FieldViewModel
@@ -55,18 +58,20 @@ fun RequestsScreen(navController: NavHostController) {
     val listMode by requestViewModel.listMode.collectAsState()
     val receivedRequests by requestViewModel.receivedRequests.collectAsState()
     val sentRequests by requestViewModel.sentRequests.collectAsState()
-    val requestFields = if (listMode == RequestViewModel.RequestListMode.SENT) {
-        sentRequests
-    } else {
-        receivedRequests
-    }
+    val draftFields by requestViewModel.draftFields.collectAsState()
+    val isLoading by requestViewModel.isLoading.collectAsState()
+    val requestFields = if (listMode == RequestViewModel.RequestListMode.SENT) sentRequests else receivedRequests
 
     var openAddDialog by remember { mutableStateOf(false) }
     var snackbarMessage by remember { mutableStateOf<String?>(null) }
     var openSendDialog by remember { mutableStateOf(false) }
+    var openMatchingDialog by remember { mutableStateOf(false) }
+    var activeRequest by remember { mutableStateOf<RequestDomain?>(null) }
+    val selectedDraftFields = remember { mutableStateListOf<FieldDomain>() }
 
     // ---- Checked rows (Domain) ----
     val selectedFields by fieldViewModel.selectedFields.collectAsState()
+    val storedFields by fieldViewModel.fields.collectAsState()
 
     LaunchedEffect(snackbarMessage) {
         snackbarMessage?.let {
@@ -80,7 +85,7 @@ fun RequestsScreen(navController: NavHostController) {
         requestViewModel.events.collect { event ->
             when (event) {
                 is com.shary.app.core.domain.interfaces.events.RequestEvent.FetchedFromCloud -> {
-                    snackbarMessage = "Fetched and matched ${event.matchedCount} fields from request"
+                    snackbarMessage = "Fetched request with ${event.matchedCount} fields"
                 }
                 is com.shary.app.core.domain.interfaces.events.RequestEvent.FetchError -> {
                     snackbarMessage = "Fetch error: ${event.throwable.message}"
@@ -97,7 +102,7 @@ fun RequestsScreen(navController: NavHostController) {
                 Lifecycle.Event.ON_START -> Unit
                 Lifecycle.Event.ON_STOP -> {
                     // Persist a Request built from the current local list
-                    if (listMode == RequestViewModel.RequestListMode.RECEIVED && requestFields.isNotEmpty()) {
+                    if (listMode == RequestViewModel.RequestListMode.RECEIVED && selectedFields.isNotEmpty()) {
                         fieldViewModel.setSelectedFields()
                     }
                 }
@@ -110,281 +115,382 @@ fun RequestsScreen(navController: NavHostController) {
     }
 
     // ---------------- UI ----------------
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("Requests") },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = colorScheme.primaryContainer,
-                    titleContentColor = colorScheme.primary
-                ),
-                expandedHeight = 64.dp
-            )
-        },
-        floatingActionButton = {
-            val selectionEnabled = listMode == RequestViewModel.RequestListMode.RECEIVED
-            val selectionAvailable = selectionEnabled && selectedFields.isNotEmpty()
+    LoadingOverlay(isLoading = isLoading) {
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = { Text("Requests") },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = colorScheme.primaryContainer,
+                        titleContentColor = colorScheme.primary
+                    ),
+                    expandedHeight = 64.dp
+                )
+            },
+            floatingActionButton = {
+                val isReceiveMode = listMode == RequestViewModel.RequestListMode.RECEIVED
+                val isSendMode = listMode == RequestViewModel.RequestListMode.SENT
+                val selectedSendAvailable = selectedDraftFields.isNotEmpty()
+                val selectedReceiveAvailable = selectedFields.isNotEmpty()
+                val requestReadyToSend = draftFields.isNotEmpty() && userViewModel.anyCachedUser()
 
-            HorizontalDivider(thickness = 1.dp)
+                HorizontalDivider(thickness = 1.dp)
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // ---- Left: Delete ----
-                Box(
-                    modifier = Modifier
-                        .weight(0.15f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CompactActionButton(
-                        onClick = {
-                            if (selectionAvailable) {
-                                fieldViewModel.deleteFields(selectedFields)
-                                fieldViewModel.clearSelectedFields()
-                                snackbarMessage = "Deleted ${selectedFields.size} fields"
-                            }
-                        },
-                        backgroundColor = colorScheme.error,
-                        icon = Icons.Default.Delete,
-                        contentDescription = "Delete Fields",
-                        enabled = selectionAvailable
-                    )
-                }
-
-                // ---- Center: Add + Download + Users ----
                 Row(
-                    modifier = Modifier.weight(0.70f),
-                    horizontalArrangement = Arrangement.spacedBy(32.dp, Alignment.CenterHorizontally),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    CompactActionButton(
-                        onClick = { openAddDialog = true },
-                        icon = Icons.Default.Add,
-                        backgroundColor = colorScheme.primary,
-                        contentDescription = "Add Field",
-                        enabled = selectionEnabled
-                    )
-
-                    CompactActionButton(
-                        onClick = {
-                            val currentUser = userViewModel.getOwner()
-                            if (currentUser.username.isNotEmpty()) {
-                                requestViewModel.fetchRequestsFromCloud(currentUser.username, currentUser)
-                            } else {
-                                snackbarMessage = "User not logged in"
-                            }
-                        },
-                        icon = Icons.Default.CloudDownload,
-                        backgroundColor = colorScheme.primary,
-                        contentDescription = "Fetch Requests from Cloud",
-                        enabled = selectionEnabled
-                    )
-
-                    CompactActionButton(
-                        onClick = { navController.navigate(Screen.Users.route) },
-                        icon = Icons.Default.Person,
-                        backgroundColor = colorScheme.primary,
-                        contentDescription = "Send to Users",
-                        enabled = selectionEnabled
-                    )
-                }
-
-                // ---- Right: Summary ----
-                Box(
-                    modifier = Modifier
-                        .weight(0.15f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CompactActionButton(
-                        onClick = {
-                            if (userViewModel.anyCachedUser() && selectedFields.isNotEmpty()) {
-                                navController.navigate(Screen.Summary.route)
-                            }
-                        },
-                        icon = Icons.Default.AssignmentTurnedIn,
-                        backgroundColor = colorScheme.tertiary,
-                        contentDescription = "Summary",
-                        enabled = selectionAvailable && userViewModel.anyCachedUser()
-                    )
-                }
-            }
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .padding(16.dp)
-                .fillMaxWidth()
-                .fillMaxHeight(0.90f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            SingleChoiceSegmentedButtonRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 12.dp)
-            ) {
-                SegmentedButton(
-                    selected = listMode == RequestViewModel.RequestListMode.RECEIVED,
-                    onClick = { requestViewModel.setListMode(RequestViewModel.RequestListMode.RECEIVED) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
-                ) {
-                    Text("Received Requests")
-                }
-                SegmentedButton(
-                    selected = listMode == RequestViewModel.RequestListMode.SENT,
-                    onClick = { requestViewModel.setListMode(RequestViewModel.RequestListMode.SENT) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                ) {
-                    Text("Sent Requests")
-                }
-            }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-            ) {
-                Text(
-                    "Key",
-                    Modifier.weight(1f),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    "Key Alias",
-                    Modifier.weight(1f),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray)
-
-            if (requestFields.isNotEmpty()) {
-                LazyColumn(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    contentPadding = PaddingValues(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    itemsIndexed(
-                        items = requestFields,
-                        key = { _, request -> request.dateAdded } // stable key
-                    ) { index, request ->
-                        val isSelected = request.fields.isNotEmpty() && request.fields.all { it in selectedFields }
-                        val selectionEnabled = listMode == RequestViewModel.RequestListMode.RECEIVED
-
-                        // background colors
-                        val backgroundColor = when {
-                            isSelected -> colorScheme.secondaryContainer
-                            index % 2 == 0 -> colorScheme.surface
-                            else -> colorScheme.surfaceVariant
-                        }
-
-                        ElevatedCard(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .wrapContentHeight()
-                                .alpha(if (isSelected) 1f else 0.9f),
-                            colors = CardDefaults.elevatedCardColors(
-                                containerColor = backgroundColor
-                            ),
-                            enabled = selectionEnabled,
+                    // ---- Left: Delete ----
+                    Box(
+                        modifier = Modifier
+                            .weight(0.15f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CompactActionButton(
                             onClick = {
-                                // If all fields in the request are already selected, unselect them all.
-                                // Otherwise, select all of them.
-                                if (selectionEnabled) {
-                                    if (isSelected) {
-                                        request.fields.forEach {
-                                            fieldViewModel.toggleFieldSelection(it) // Will unselect
+                                if (isReceiveMode && selectedReceiveAvailable) {
+                                    fieldViewModel.deleteFields(selectedFields)
+                                    fieldViewModel.clearSelectedFields()
+                                    snackbarMessage = "Deleted ${selectedFields.size} fields"
+                                }
+                                if (isSendMode && selectedSendAvailable) {
+                                    val removedCount = selectedDraftFields.size
+                                    requestViewModel.removeDraftFields(selectedDraftFields.toList())
+                                    selectedDraftFields.clear()
+                                    snackbarMessage = "Removed $removedCount fields"
+                                }
+                            },
+                            backgroundColor = colorScheme.error,
+                            icon = Icons.Default.Delete,
+                            contentDescription = "Delete Fields",
+                            enabled = (isReceiveMode && selectedReceiveAvailable) || (isSendMode && selectedSendAvailable)
+                        )
+                    }
+
+                    // ---- Center: Add + Download + Users ----
+                    Row(
+                        modifier = Modifier.weight(0.70f),
+                        horizontalArrangement = Arrangement.spacedBy(32.dp, Alignment.CenterHorizontally),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CompactActionButton(
+                            onClick = { openAddDialog = true },
+                            icon = Icons.Default.Add,
+                            backgroundColor = colorScheme.primary,
+                            contentDescription = "Add Field",
+                            enabled = isSendMode
+                        )
+
+                        CompactActionButton(
+                            onClick = {
+                                val currentUser = userViewModel.getOwner()
+                                if (currentUser.username.isNotEmpty()) {
+                                    requestViewModel.fetchRequestsFromCloud(currentUser.username, currentUser)
+                                } else {
+                                    snackbarMessage = "User not logged in"
+                                }
+                            },
+                            icon = Icons.Default.CloudDownload,
+                            backgroundColor = colorScheme.primary,
+                            contentDescription = "Fetch Requests from Cloud",
+                            enabled = isReceiveMode
+                        )
+
+                        CompactActionButton(
+                            onClick = { navController.navigate(Screen.Users.route) },
+                            icon = Icons.Default.Person,
+                            backgroundColor = colorScheme.primary,
+                            contentDescription = "Send to Users",
+                            enabled = isReceiveMode || isSendMode
+                        )
+                    }
+
+                    // ---- Right: Summary ----
+                    Box(
+                        modifier = Modifier
+                            .weight(0.15f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CompactActionButton(
+                            onClick = {
+                                if (isReceiveMode && selectedReceiveAvailable && userViewModel.anyCachedUser()) {
+                                    fieldViewModel.setSelectedFields()
+                                    navController.navigate(Screen.Summary.route)
+                                }
+                                if (isSendMode && requestReadyToSend) {
+                                    openSendDialog = true
+                                }
+                            },
+                            icon = Icons.Default.AssignmentTurnedIn,
+                            backgroundColor = colorScheme.tertiary,
+                            contentDescription = "Summary",
+                            enabled = (isReceiveMode && selectedReceiveAvailable && userViewModel.anyCachedUser()) || requestReadyToSend
+                        )
+                    }
+                }
+            },
+            snackbarHost = { SnackbarHost(snackbarHostState) }
+        ) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.90f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SingleChoiceSegmentedButtonRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 12.dp)
+                ) {
+                    SegmentedButton(
+                        selected = listMode == RequestViewModel.RequestListMode.RECEIVED,
+                        onClick = { requestViewModel.setListMode(RequestViewModel.RequestListMode.RECEIVED) },
+                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                    ) {
+                        Text("Receive")
+                    }
+                    SegmentedButton(
+                        selected = listMode == RequestViewModel.RequestListMode.SENT,
+                        onClick = { requestViewModel.setListMode(RequestViewModel.RequestListMode.SENT) },
+                        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                    ) {
+                        Text("Send")
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                ) {
+                    Text(
+                        "Key",
+                        Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "Key Alias",
+                        Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray)
+
+                when {
+                    listMode == RequestViewModel.RequestListMode.SENT && draftFields.isNotEmpty() -> {
+                        LazyColumn(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            contentPadding = PaddingValues(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            itemsIndexed(
+                                items = draftFields,
+                                key = { _, field -> "${field.key}-${field.dateAdded}" }
+                            ) { index, field ->
+                                val isSelected = selectedDraftFields.contains(field)
+                                val backgroundColor = when {
+                                    isSelected -> colorScheme.secondaryContainer
+                                    index % 2 == 0 -> colorScheme.surface
+                                    else -> colorScheme.surfaceVariant
+                                }
+
+                                ElevatedCard(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .wrapContentHeight()
+                                        .alpha(if (isSelected) 1f else 0.9f),
+                                    colors = CardDefaults.elevatedCardColors(
+                                        containerColor = backgroundColor
+                                    ),
+                                    onClick = {
+                                        if (isSelected) {
+                                            selectedDraftFields.remove(field)
+                                        } else {
+                                            selectedDraftFields.add(field)
                                         }
-                                    } else {
-                                        request.fields.forEach {
-                                            if (it !in selectedFields) {
-                                                fieldViewModel.toggleFieldSelection(it) // Will select only those not yet selected
+                                    }
+                                ) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text(
+                                            field.key,
+                                            modifier = Modifier.weight(1f),
+                                            style = MaterialTheme.typography.bodyLarge
+                                        )
+                                        Text(
+                                            field.keyAlias.orEmpty(),
+                                            modifier = Modifier.weight(1f),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = Color.Gray
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    listMode == RequestViewModel.RequestListMode.RECEIVED && requestFields.isNotEmpty() -> {
+                        LazyColumn(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            contentPadding = PaddingValues(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            itemsIndexed(
+                                items = requestFields,
+                                key = { _, request -> request.dateAdded } // stable key
+                            ) { index, request ->
+                                val backgroundColor = when {
+                                    index % 2 == 0 -> colorScheme.surface
+                                    else -> colorScheme.surfaceVariant
+                                }
+
+                                ElevatedCard(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .wrapContentHeight(),
+                                    colors = CardDefaults.elevatedCardColors(
+                                        containerColor = backgroundColor
+                                    ),
+                                    onClick = {
+                                        activeRequest = request
+                                        openMatchingDialog = true
+                                    },
+                                ) {
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp)
+                                    ) {
+                                        Text(
+                                            "Request from ${request.sender.username}",
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            fontWeight = FontWeight.SemiBold
+                                        )
+                                        Spacer(modifier = Modifier.height(8.dp))
+                                        request.fields.forEach { field ->
+                                            Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                verticalAlignment = Alignment.CenterVertically
+                                            ) {
+                                                Text(
+                                                    field.key,
+                                                    modifier = Modifier.weight(1f),
+                                                    style = MaterialTheme.typography.bodyMedium
+                                                )
+                                                Text(
+                                                    field.keyAlias.orEmpty(),
+                                                    modifier = Modifier.weight(1f),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = Color.Gray
+                                                )
                                             }
                                         }
                                     }
                                 }
-                            },
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    request.fields.joinToString { it.key },
-                                    modifier = Modifier.weight(1f),
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
-                                Text(
-                                    request.fields.joinToString { it.keyAlias.orEmpty() },
-                                    modifier = Modifier.weight(1f),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = Color.Gray
-                                )
                             }
                         }
                     }
-                }
 
-            } else {
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text("No requests available", style = MaterialTheme.typography.bodyMedium)
-                }
-            }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray)
-        }
+                    listMode == RequestViewModel.RequestListMode.SENT -> {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("No fields added yet", style = MaterialTheme.typography.bodyMedium)
+                        }
+                    }
 
-        // Add field (for the in-progress request)
-        if (openAddDialog) {
-            AddRequestDialog(
-                onDismiss = { openAddDialog = false },
-                onAddRequest = { key, keyAlias ->
-                    if (key.isNotBlank()) {
-                        val field = FieldDomain(
-                            key = key.trim(),
-                            keyAlias = keyAlias.trim(),
-                            value = "", // requests only need the key; keep value empty
-                            tag = Tag.Unknown,
-                            dateAdded = Instant.now()
-                        )
-                        //requestFields.add(field)
-                        openAddDialog = false
-                        snackbarMessage = "Requested key '$key' added"
-                    } else {
-                        snackbarMessage = "Requested key is required"
+                    else -> {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("No requests available", style = MaterialTheme.typography.bodyMedium)
+                        }
                     }
                 }
-            )
-        }
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray)
+            }
 
-        // Send (placeholder)
-        if (openSendDialog) {
-            SendRequestDialog(
-                onDismiss = { openSendDialog = false },
-                onSend = {
-                    openSendDialog = false
-                    cloudViewModel.uploadData(
-                        selectedFields,
-                        userViewModel.getOwner(),
-                        userViewModel.getCachedUsers(),
-                        true
-                    )
-                }
-            )
+            // Add field (for the in-progress request)
+            if (openAddDialog) {
+                AddRequestDialog(
+                    onDismiss = { openAddDialog = false },
+                    onAddRequest = { key, keyAlias ->
+                        if (key.isNotBlank()) {
+                            val field = FieldDomain(
+                                key = key.trim(),
+                                keyAlias = keyAlias.trim(),
+                                value = "", // requests only need the key; keep value empty
+                                tag = Tag.Unknown,
+                                dateAdded = Instant.now()
+                            )
+                            requestViewModel.addDraftField(field)
+                            openAddDialog = false
+                            snackbarMessage = "Requested key '$key' added"
+                        } else {
+                            snackbarMessage = "Requested key is required"
+                        }
+                    }
+                )
+            }
+
+            if (openMatchingDialog && activeRequest != null) {
+                FieldMatchingDialog(
+                    storedFields = storedFields,
+                    requestKeys = activeRequest!!.fields.map { it.key to it.keyAlias.orEmpty() },
+                    onDismiss = {
+                        openMatchingDialog = false
+                        activeRequest = null
+                    },
+                    onAccept = { matchedFields ->
+                        fieldViewModel.setSelectedFields(matchedFields)
+                        snackbarMessage = "Matched ${matchedFields.size} fields"
+                        openMatchingDialog = false
+                        activeRequest = null
+                    },
+                    onAddField = { newField ->
+                        fieldViewModel.addField(newField)
+                    }
+                )
+            }
+
+            if (openSendDialog) {
+                SendRequestDialog(
+                    onDismiss = { openSendDialog = false },
+                    onSend = {
+                        openSendDialog = false
+                        cloudViewModel.uploadData(
+                            draftFields,
+                            userViewModel.getOwner(),
+                            userViewModel.getCachedUsers(),
+                            true
+                        )
+                        requestViewModel.clearDraftFields()
+                        selectedDraftFields.clear()
+                        snackbarMessage = "Request sent"
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/shary/app/utils/Functions.kt
+++ b/app/src/main/java/com/shary/app/utils/Functions.kt
@@ -33,7 +33,9 @@ object Functions {
         val json = JSONObject()
         json.put("mode", "request")
         json.put("sender", sender)
-        json.put("keys", fields.forEach { field -> field.key })
+        val keys = org.json.JSONArray()
+        fields.forEach { field -> keys.put(field.key) }
+        json.put("keys", keys)
         return json.toString(4)
     }
 

--- a/app/src/main/java/com/shary/app/viewmodels/field/FieldViewModel.kt
+++ b/app/src/main/java/com/shary/app/viewmodels/field/FieldViewModel.kt
@@ -192,7 +192,12 @@ class FieldViewModel @Inject constructor(
     }
 
     fun setSelectedFields() {
-        val selectedFields = _selectedFields.value.distinctBy { it.key.lowercase() }
+        setSelectedFields(_selectedFields.value)
+    }
+
+    fun setSelectedFields(fields: List<FieldDomain>) {
+        val selectedFields = fields.distinctBy { it.key.lowercase() }
+        _selectedFields.value = selectedFields
         cacheSelection.cacheFields(selectedFields) // <— persistencia cross-screen
     }
 


### PR DESCRIPTION
### Motivation

- Rework the Requests UI to clearly separate composing/sending requests from receiving/processing incoming requests.
- Allow building a multi-field draft to send to selected users instead of a single ephemeral field.
- Provide a way to fetch request payloads from the cloud and start the existing field-matching flow against local stored fields.
- Fix request payload JSON generation to produce a proper `keys` array for uploads.

### Description

- Changed the `RequestsScreen` UI to use `Send` and `Receive` modes (instead of “Sent Requests” / “Received Requests”), added a draft list for send mode, and integrated `FieldMatchingDialog` for received requests.
- Added draft request state and operations in `RequestViewModel` (`draftFields`, `addDraftField`, `removeDraftFields`, `clearDraftFields`, `isLoading`) and wrapped the screen with `LoadingOverlay` while fetching.
- Updated `fetchRequestsFromCloud` in `RequestViewModel` to parse the incoming `keys` array and persist a `RequestDomain` (previously attempted to match immediately), and emit a `FetchedFromCloud` event with count.
- Extended `FieldViewModel.setSelectedFields` to accept an explicit list so matched fields from the matching dialog can be persisted, and fixed `Functions.makeJsonStringFromRequestKeys` to produce a JSON array for `keys`.

### Testing

- No automated tests were executed as part of this change.
- Manual smoke: code was compiled locally when committing the change (no CI run recorded).
- Static code edits were validated by running repository searches and quick file inspections.
- Further automated unit/integration tests should be added to cover `RequestViewModel` flows and JSON payload generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec0c1dfd48326a52aa9b3a9eb590e)