### PR TITLE
Show per-request keys in Requests screen and add owned/responded flags to Request model

### DIFF
--- a/app/src/main/java/com/shary/app/core/domain/models/RequestDomain.kt
+++ b/app/src/main/java/com/shary/app/core/domain/models/RequestDomain.kt
@@ -8,7 +8,9 @@ data class RequestDomain(
     val fields: List<FieldDomain>,
     val user: UserDomain,
     val recipients: List<UserDomain>,
-    val dateAdded: Instant
+    val dateAdded: Instant,
+    val owned: Boolean,
+    val responded: Boolean
 ) {
 
     companion object {
@@ -24,7 +26,9 @@ data class RequestDomain(
                 fields = fields,
                 user = user,
                 recipients = recipients,
-                dateAdded = Instant.now()
+                dateAdded = Instant.now(),
+                owned = true,
+                responded = false
             )
         }
 
@@ -32,7 +36,9 @@ data class RequestDomain(
             fields = emptyList(),
             user = UserDomain(),
             recipients = emptyList(),
-            dateAdded = Instant.now()
+            dateAdded = Instant.now(),
+            owned = false,
+            responded = false
         )
     }
 }
@@ -44,5 +50,7 @@ fun RequestDomain.reset(): RequestDomain = this.copy(
     fields = emptyList(),
     user = UserDomain(),
     recipients = emptyList(),
-    dateAdded = Instant.EPOCH
+    dateAdded = Instant.EPOCH,
+    owned = false,
+    responded = false
 )

--- a/app/src/main/java/com/shary/app/infrastructure/mappers/mappers.kt
+++ b/app/src/main/java/com/shary/app/infrastructure/mappers/mappers.kt
@@ -66,7 +66,9 @@ fun RequestProto.toDomain(codec: FieldCodec): RequestDomain =
         fields = fieldsList.toDomainFields(codec),
         dateAdded = Instant.ofEpochMilli(dateAdded),
         user = user.toDomain(),
-        recipients = recipientsList.map { it.toDomain() }
+        recipients = recipientsList.map { it.toDomain() },
+        owned = owned,
+        responded = responded
     )
 
 fun RequestDomain.toProto(codec: FieldCodec): RequestProto =
@@ -75,6 +77,8 @@ fun RequestDomain.toProto(codec: FieldCodec): RequestProto =
         .setDateAdded(dateAdded.toEpochMilli())
         .setUser(user.toProto())
         .addAllRecipients(recipients.map { it.toProto() })
+        .setOwned(owned)
+        .setResponded(responded)
         .build()
 
 // ======================================================================

--- a/app/src/main/java/com/shary/app/ui/screens/request/RequestScreen.kt
+++ b/app/src/main/java/com/shary/app/ui/screens/request/RequestScreen.kt
@@ -60,7 +60,7 @@ fun RequestsScreen(navController: NavHostController) {
     val draftFields by requestViewModel.draftFields.collectAsState()
     val receivedRequests by requestViewModel.receivedRequests.collectAsState()
     val sentRequests by requestViewModel.sentRequests.collectAsState()
-    val requestFields = if (listMode == RequestListMode.SENT) {
+    val requestsToShow = if (listMode == RequestListMode.SENT) {
         sentRequests
     } else {
         receivedRequests
@@ -258,6 +258,13 @@ fun RequestsScreen(navController: NavHostController) {
             // ----------------------------------------------------------------
             // -------------------- List of Received or Requested Fields --------------------
             // ----------------------------------------------------------------
+            Text(
+                if (listMode == RequestListMode.SENT) "Sent Requests" else "Received Requests",
+                modifier = Modifier.padding(vertical = 8.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold
+            )
 
             Row(
                 modifier = Modifier
@@ -265,13 +272,7 @@ fun RequestsScreen(navController: NavHostController) {
                     .padding(vertical = 8.dp)
             ) {
                 Text(
-                    "Key",
-                    Modifier.weight(1f),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    "Key Alias",
+                    "Requested Keys",
                     Modifier.weight(1f),
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold
@@ -280,9 +281,9 @@ fun RequestsScreen(navController: NavHostController) {
 
             HorizontalDivider(thickness = 1.dp, color = Color.Gray)
 
-            if (requestFields.isNotEmpty()) {
-                Log.d("RequestsScreen", "requestFields: $requestFields")
-                Log.d("Number of requests", "${requestFields.size}")
+            if (requestsToShow.isNotEmpty()) {
+                Log.d("RequestsScreen", "requestsToShow: $requestsToShow")
+                Log.d("Number of requests", "${requestsToShow.size}")
                 LazyColumn(
                     modifier = Modifier
                         .weight(1f)
@@ -291,7 +292,7 @@ fun RequestsScreen(navController: NavHostController) {
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     itemsIndexed(
-                        items = requestFields,
+                        items = requestsToShow,
                         key = { _, request -> request.dateAdded } // stable key
                     ) { index, request ->
                         val isSelected =
@@ -339,15 +340,9 @@ fun RequestsScreen(navController: NavHostController) {
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Text(
-                                    request.fields.joinToString { it.key },
+                                    request.fields.joinToString { it.key }.ifBlank { "No keys requested" },
                                     modifier = Modifier.weight(1f),
                                     style = MaterialTheme.typography.bodyLarge
-                                )
-                                Text(
-                                    request.fields.joinToString { it.keyAlias },
-                                    modifier = Modifier.weight(1f),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = Color.Gray
                                 )
                             }
                         }
@@ -361,126 +356,120 @@ fun RequestsScreen(navController: NavHostController) {
                         .fillMaxWidth(),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text("No requests available", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        if (listMode == RequestListMode.SENT) {
+                            "No sent requests available"
+                        } else {
+                            "No received requests available"
+                        },
+                        style = MaterialTheme.typography.bodyMedium
+                    )
                 }
             }
 
-            HorizontalDivider(
-                modifier = Modifier.fillMaxHeight(0.5f),
-                thickness = 1.dp,
-                color = Color.Gray
-            )
-
-            // ----------------------------------------------------------------
-            // -------------------- List of Drafted Fields --------------------
-            // ----------------------------------------------------------------
-
-            Text(
-                "Drafted Fields",
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(vertical = 8.dp)
-
-                ,
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Bold
-            )
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-            ) {
-                Text(
-                    "Key",
-                    Modifier.weight(1f),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold
+            if (listMode == RequestListMode.SENT) {
+                HorizontalDivider(
+                    modifier = Modifier.fillMaxHeight(0.5f),
+                    thickness = 1.dp,
+                    color = Color.Gray
                 )
+
+                // ----------------------------------------------------------------
+                // -------------------- List of Drafted Fields --------------------
+                // ----------------------------------------------------------------
+
                 Text(
-                    "Key Alias",
-                    Modifier.weight(1f),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray)
-
-            if (draftFields.isNotEmpty()) {
-                Log.d("RequestsScreen", "draftFields: $draftFields")
-                Log.d("Number of requests", "${draftFields.size}")
-                LazyColumn(
+                    "Drafted Fields",
                     modifier = Modifier
-                        //.weight(1f)
-                        .fillMaxWidth(),
-                    contentPadding = PaddingValues(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                        .weight(1f)
+                        .padding(vertical = 8.dp),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
                 ) {
-                    itemsIndexed(
-                        items = draftFields,
-                        key = { _, field -> field.dateAdded } // stable key
-                    ) { index, field ->
-                        //val isSelected = field.key.isNotEmpty()
-                        //val selectionEnabled = listMode == RequestViewModel.RequestListMode.RECEIVED
+                    Text(
+                        "Key",
+                        Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "Key Alias",
+                        Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
 
-                        // background colors
-                        /*
-                        val backgroundColor = when {
-                            isSelected -> colorScheme.secondaryContainer
-                            index % 2 == 0 -> colorScheme.surface
-                            else -> colorScheme.surfaceVariant
-                        }
-                        */
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray)
 
-                        ElevatedCard(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .wrapContentHeight(),
-                            //.alpha(if (isSelected) 1f else 0.9f),
-                            colors = CardDefaults.elevatedCardColors(
-                                containerColor = colorScheme.surface
-                            ),
-                            enabled = true,
-                            onClick = {},
-                        ) {
-                            Row(
+                if (draftFields.isNotEmpty()) {
+                    Log.d("RequestsScreen", "draftFields: $draftFields")
+                    Log.d("Number of requests", "${draftFields.size}")
+                    LazyColumn(
+                        modifier = Modifier
+                            //.weight(1f)
+                            .fillMaxWidth(),
+                        contentPadding = PaddingValues(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        itemsIndexed(
+                            items = draftFields,
+                            key = { _, field -> field.dateAdded } // stable key
+                        ) { _, field ->
+                            ElevatedCard(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                                    .wrapContentHeight(),
+                                colors = CardDefaults.elevatedCardColors(
+                                    containerColor = colorScheme.surface
+                                ),
+                                enabled = true,
+                                onClick = {},
                             ) {
-                                Text(
-                                    field.key,
-                                    modifier = Modifier.weight(1f),
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
-                                Text(
-                                    field.keyAlias.orEmpty(),
-                                    modifier = Modifier.weight(1f),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = Color.Gray
-                                )
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        field.key,
+                                        modifier = Modifier.weight(1f),
+                                        style = MaterialTheme.typography.bodyLarge
+                                    )
+                                    Text(
+                                        field.keyAlias.orEmpty(),
+                                        modifier = Modifier.weight(1f),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = Color.Gray
+                                    )
+                                }
                             }
                         }
                     }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("No drafted fields available", style = MaterialTheme.typography.bodyMedium)
+                    }
                 }
-            } else {
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text("No drafted fields available", style = MaterialTheme.typography.bodyMedium)
-                }
+                HorizontalDivider(
+                    modifier = Modifier.fillMaxHeight(1.0f),
+                    thickness = 1.dp,
+                    color = Color.Gray
+                )
             }
-            HorizontalDivider(
-                modifier = Modifier.fillMaxHeight(1.0f),
-                thickness = 1.dp,
-                color = Color.Gray
-            )
         }
     }
 

--- a/app/src/main/java/com/shary/app/viewmodels/communication/CloudViewModel.kt
+++ b/app/src/main/java/com/shary/app/viewmodels/communication/CloudViewModel.kt
@@ -85,7 +85,9 @@ class CloudViewModel @Inject constructor(
                 fields = fields,
                 user = owner,
                 recipients = recipients,
-                dateAdded = Instant.now()
+                dateAdded = Instant.now(),
+                owned = true,
+                responded = false
             )
             runCatching {
                 withContext(Dispatchers.IO) {
@@ -98,4 +100,3 @@ class CloudViewModel @Inject constructor(
         }
     }
 }
-

--- a/app/src/main/java/com/shary/app/viewmodels/request/RequestViewModel.kt
+++ b/app/src/main/java/com/shary/app/viewmodels/request/RequestViewModel.kt
@@ -154,7 +154,9 @@ class RequestViewModel @Inject constructor(
                             fields = requestedFields,
                             user = user,
                             recipients = listOf(currentUser),
-                            dateAdded = Instant.now()
+                            dateAdded = Instant.now(),
+                            owned = false,
+                            responded = false
                         )
 
                         // Save request

--- a/app/src/main/proto/request.proto
+++ b/app/src/main/proto/request.proto
@@ -12,6 +12,8 @@ message Request {
   User user = 3;
   repeated User recipients = 4;
   int64 dateAdded = 5;
+  bool owned = 6;
+  bool responded = 7;
 }
 
 message RequestList {


### PR DESCRIPTION
### Motivation
- Surface the loaded requests in the Requests UI showing each request's keys so users can inspect per-request data in the `Received` and `Sent` views. 
- Move the drafted-fields panel to appear only when `Sent` is selected to match the new layout requirement. 
- Persist metadata indicating ownership and response state for requests so repository- and cloud-driven flows can distinguish local vs external requests. 
- Propagate the new metadata through mapping, repository and viewmodel flows to keep model and storage consistent.

### Description
- Added `owned` and `responded` boolean fields to the `Request` proto and to the domain model `RequestDomain` and initialized defaults. 
- Updated mappers (`RequestProto.toDomain` and `RequestDomain.toProto`) to include `owned` and `responded` when converting between proto and domain. 
- Set `owned=true`/`responded=false` for requests created in `uploadRequest` (sent) and set `owned=false`/`responded=false` for requests created in `fetchRequestsFromCloud` (received). 
- Reworked `RequestsScreen` UI to use a `requestsToShow` list, render each request as a row listing its requested keys, and display the drafted-fields list only when `RequestListMode.SENT` is active.

### Testing
- No automated tests were executed as part of this change. 
- The repository files modified include `app/src/main/proto/request.proto`, `RequestDomain`, mapper functions in `mappers.kt`, the `RequestsScreen` UI, and the `CloudViewModel`/`RequestViewModel` code paths touched for request creation. 
- Manual verification is recommended to run a full build and exercise `fetchRequestsFromCloud` and `uploadRequest` scenarios to confirm persistence and UI behavior. 
- Consider adding unit/UI tests for `Request` mapping and `RequestsScreen` rendering in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ada8440483269d430124409beaa4)