### PR TITLE
Simplify field matching dialog flow

### DIFF
--- a/app/src/main/java/com/shary/app/ui/screens/utils/FunctionUtils.kt
+++ b/app/src/main/java/com/shary/app/ui/screens/utils/FunctionUtils.kt
@@ -1,7 +1,6 @@
 package com.shary.app.ui.screens.utils
 
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.shary.app.core.domain.models.FieldDomain
 
 object FunctionUtils {
 
@@ -9,13 +8,10 @@ object FunctionUtils {
         storageIdx: Int?,
         requestIdx: Int?,
         matches: SnapshotStateList<Triple<Int, Int, Int>>,
-        storedFieldsSelection: SnapshotStateList<FieldDomain>,
-        storedFields: List<FieldDomain>,
         freeLabelsFromUnmatched: SnapshotStateList<Int>,
         isStorageFirst: Boolean,
         onUnselect: () -> Unit,
         onIsStorageFirst: (Boolean) -> Unit,
-        onMatchCreated: (Triple<Int, Int, Int>) -> Unit,
         onFreeLabelStored: (Int) -> Unit
     ) {
         if (storageIdx != null && requestIdx == null) onIsStorageFirst(true)
@@ -45,8 +41,6 @@ object FunctionUtils {
                 }
                 val newMatch = Triple(storageIdx, requestIdx, newLabel)
                 matches.add(newMatch)
-                storedFieldsSelection.add(storedFields[storageIdx])
-                onMatchCreated(newMatch)
             }
 
             isStorageMatched && !isRequestMatched -> {
@@ -80,9 +74,6 @@ object FunctionUtils {
                     onFreeLabelStored(storageOldMatch.third)
                     Triple(storageIdx, requestIdx, requestOldMatch.third)
                 }
-
-                storedFieldsSelection.add(storedFields[storageIdx])
-                onMatchCreated(newTriple)
             }
         }
 


### PR DESCRIPTION
### Motivation
- Simplify the matching logic between stored fields and requested keys to reduce coupling and side effects.
- Allow creating new fields directly inside the matching dialog and have them available immediately for matching.
- Ensure the dialog accept action is enabled reliably when all request keys are matched so the user can proceed to the summary.

### Description
- Remove `storedFields`, `storedFieldsSelection`, and `onMatchCreated` parameters and side-effects from `FunctionUtils.matchIfPossible` to make it pure-state with minimal responsibilities.
- Add a `localStoredFields` `mutableStateListOf` in `FieldMatchingDialog` and initialize it via `LaunchedEffect` from the incoming `storedFields` prop.
- Use `localStoredFields` for the left column and for `buildAcceptedSelection()`, and wire `AddFieldDialog` to append new fields to `localStoredFields` while also invoking the external `onAddField` callback.
- Simplify match-completion logic by computing `isFullyMatched = matches.size == requestKeys.size` and remove selection-blocking checks that prevented toggles when matched.

### Testing
- Attempted to run lint with `./gradlew -q :app:lintDebug`, but the command failed due to a permission error in this environment.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc4793cac83269493c0b6158189e6)